### PR TITLE
Fix: ansible-galaxy minus to underscore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while-true-do.pcengines-apu-firmware
+  - ln -s  $PWD ../while_true_do.pcengines-apu-firmware
 
 # Run the tests
 script:

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Automating firmware updates is essential to a secure environment.
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while-true-do/pcengines-apu-firmware)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/pcengines-apu-firmware)
 
 ```
-ansible-galaxy install while-true-do.pcengines-apu-firmware
+ansible-galaxy install while_true_do.pcengines-apu-firmware
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-pcengines-apu-firmware)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-pcengines-apu-firmware.git while-true-do.pcengines-apu-firmware
+git clone https://github.com/while-true-do/ansible-role-pcengines-apu-firmware.git while_true_do.pcengines-apu-firmware
 ```
 
 ## Requirements
@@ -82,7 +82,7 @@ Simple Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while-true-do.pcengines-apu-firmware }
+    - { role: while_true_do.pcengines-apu-firmware }
 ```
 
 Advanced Example:
@@ -90,7 +90,7 @@ Advanced Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while-true-do.pcengines-apu-firmware, wtd_pcengines_apu_firmware_autoreboot: true, wtd_pcengines_apu_firmware_force_flash: true }
+    - { role: while_true_do.pcengines-apu-firmware, wtd_pcengines_apu_firmware_autoreboot: true, wtd_pcengines_apu_firmware_force_flash: true }
 ```
 
 ## Testing

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - while-true-do.repo-epel
+  - while_true_do.repo-epel
 
 galaxy_info:
   author: while-true-do.org

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 ---
-# Install while-true-do.repo-epel from galaxy
-- src: while-true-do.repo-epel
+# Install while_true_do.repo-epel from galaxy
+- src: while_true_do.repo-epel

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while-true-do.pcengines-apu-firmware
+    - while_true_do.pcengines-apu-firmware


### PR DESCRIPTION
# Fix: ansible-galaxy minus to underscore

Ansible Galaxy decided to change "-" to "_" and there
is no way currently to roll this back.
So change the role names and galaxy links to "while_true_do"

## Reference

 - Resolves:
