### PR TITLE
Rework: use generic role for reboot tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ Used Modules:
 -   [get_url_module](https://docs.ansible.com/ansible/latest/modules/get_url_module.html)
 -   [include_tasks_module](https://docs.ansible.com/ansible/latest/modules/include_tasks_module.html)
 -   [package_module](https://docs.ansible.com/ansible/latest/modules/package_module.html)
--   [shell_module](https://docs.ansible.com/ansible/latest/modules/shell_module.html)
 -   [unarchive_module](https://docs.ansible.com/ansible/latest/modules/unarchive_module.html)
--   [wait_for_connection_module](https://docs.ansible.com/ansible/latest/modules/wait_for_connection_module.html)
 
 ## Dependencies
 
 This role depends on the below roles. You have to install them:
 
+-   [reboot](https://github.com/while-true-do/ansible-role-reboot)
 -   [repo-epel](https://github.com/while-true-do/ansible-role-repo-epel)
 
 ```

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 dependencies:
   - while_true_do.repo_epel
+  - while_true_do.reboot
 
 galaxy_info:
   role_name: firmware_pcengines_apu

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 ---
 # Install while_true_do.repo_epel from galaxy
 - src: while_true_do.repo_epel
+# Install while_true_do.reboot from galaxy
+- src: while_true_do.reboot

--- a/tasks/bios_update.yml
+++ b/tasks/bios_update.yml
@@ -37,15 +37,8 @@
     - "{{ wtd_firmware_pcengines_apu_system_product_name_cmd_result.stdout }}_{{ wtd_firmware_pcengines_apu_bios_version }}.rom.md5"
     - "{{ wtd_firmware_pcengines_apu_system_product_name_cmd_result.stdout }}_{{ wtd_firmware_pcengines_apu_bios_version }}.rom"
 
-- name: Reboot Machine
-  shell: sleep 2 && shutdown -r now "Reboot triggered from while_true_do.firmware_pcengines_apu"
-  async: 1
-  poll: 0
-  ignore_errors: True
-  when: wtd_firmware_pcengines_apu_autoreboot
-
-- name: Wait for Reboot
-  wait_for_connection:
-    timeout: 6000
-    delay: 20
-  when: wtd_firmware_pcengines_apu_autoreboot
+- name: Activate reboot handler
+  command: "true"
+  notify:
+    - Reboot Machine
+  when: wtd_pcengines_apu_firmware_autoreboot


### PR DESCRIPTION
#  Rework: use generic role for reboot tasks

- Use while_true_do.reboot handlers to perform a reboot.
If this role and another role will now use handlers they are now
triggered only once.

## Reference
 - Resolves: #4 