### PR TITLE
Rework: privilege escalation

### DIFF
--- a/tasks/bios_update.yml
+++ b/tasks/bios_update.yml
@@ -26,6 +26,7 @@
     chdir: /tmp
   register: wtd_firmware_pcengines_apu_flash_cmd_result
   failed_when: wtd_firmware_pcengines_apu_flash_cmd_result.rc != 0
+  become: yes
   when: wtd_firmware_pcengines_apu_md5check_cmd_result.rc == 0
 
 - name: Remove downloaded files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,14 +7,14 @@
     state: present
   become: yes
 
-- name: Get system-manufacturer
+- name: Get system manufacturer
   command: dmidecode -s system-manufacturer
   register: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result
   changed_when: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result.rc != 0
   failed_when: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result.rc != 0
   become: yes
 
-- name: Get system-product-name
+- name: Get system product name
   command: dmidecode -s system-product-name
   register: wtd_firmware_pcengines_apu_system_product_name_cmd_result
   changed_when: wtd_firmware_pcengines_apu_system_product_name_cmd_result.rc != 0
@@ -34,14 +34,14 @@
   become: yes
   when: wtd_firmware_pcengines_apu_bios_version == ""
 
-- name: Get bios-version
+- name: Get BIOS version
   command: dmidecode -s bios-version
   register: wtd_firmware_pcengines_apu_bios_version_cmd_result
   changed_when: wtd_firmware_pcengines_apu_bios_version_cmd_result.rc != 0
   failed_when: wtd_firmware_pcengines_apu_bios_version_cmd_result.rc != 0
   become: yes
 
-- name: Include bios update tasks
+- name: Include BIOS update tasks
   include_tasks: bios_update.yml
   when: wtd_firmware_pcengines_apu_force_flash or
         (not wtd_firmware_pcengines_apu_bios_version == "" and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,28 +5,33 @@
   package:
     name: "{{ wtd_firmware_pcengines_apu_packages }}"
     state: present
+  become: yes
 
 - name: Get system-manufacturer
   command: dmidecode -s system-manufacturer
   register: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result
   changed_when: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result.rc != 0
   failed_when: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result.rc != 0
+  become: yes
 
 - name: Get system-product-name
   command: dmidecode -s system-product-name
   register: wtd_firmware_pcengines_apu_system_product_name_cmd_result
   changed_when: wtd_firmware_pcengines_apu_system_product_name_cmd_result.rc != 0
   failed_when: wtd_firmware_pcengines_apu_system_product_name_cmd_result.rc != 0
+  become: yes
 
 - name: Fail if this board is not supported
   fail:
     msg: "The system is currently not supported by this role."
+  become: yes
   when: wtd_firmware_pcengines_apu_system_manufacturer_cmd_result.stdout != "PC Engines" or
         wtd_firmware_pcengines_apu_system_product_name_cmd_result.stdout != "apu2"
 
 - name: Fail if no BIOS version is specified
   fail:
     msg: "No BIOS version has been set. wtd_firmware_pcengines_apu_bios_version appears to be an empty string"
+  become: yes
   when: wtd_firmware_pcengines_apu_bios_version == ""
 
 - name: Get bios-version
@@ -34,6 +39,7 @@
   register: wtd_firmware_pcengines_apu_bios_version_cmd_result
   changed_when: wtd_firmware_pcengines_apu_bios_version_cmd_result.rc != 0
   failed_when: wtd_firmware_pcengines_apu_bios_version_cmd_result.rc != 0
+  become: yes
 
 - name: Include bios update tasks
   include_tasks: bios_update.yml


### PR DESCRIPTION
# Rework: privilege escalation

Use "become: yes" where necessary.
This way the role itself doesn't need to be escalated anymore.

## Reference

 - Resolves: #6